### PR TITLE
#10 fix pagination warnings

### DIFF
--- a/pages/accounts.vue
+++ b/pages/accounts.vue
@@ -233,7 +233,7 @@ export default {
     return {
       tableOptions: numItemsTableOptions,
       perPage: localStorage.numItemsTableSelected
-        ? localStorage.numItemsTableSelected
+        ? parseInt(localStorage.numItemsTableSelected)
         : 10,
       currentPage: 1,
       sortBy: `favorite`,
@@ -341,7 +341,7 @@ export default {
   },
   methods: {
     handleNumFields(num) {
-      this.perPage = num;
+      this.perPage = parseInt(num);
     },
     toggleFavorite(accountId) {
       if (this.favorites.indexOf(accountId) !== -1) {

--- a/pages/intentions.vue
+++ b/pages/intentions.vue
@@ -134,7 +134,7 @@
                   <p
                     v-b-tooltip.hover
                     class="bonded mb-0"
-                    :title="$t('pages.intention.active_bonded')"
+                    :title="$t('pages.intentions.active_bonded')"
                   >
                     {{ formatAmount(data.item.activeStake) }}
                   </p>
@@ -144,7 +144,7 @@
                     <small>
                       <span
                         v-b-tooltip.hover
-                        :title="$t('pages.intention.total_bonded')"
+                        :title="$t('pages.intentions.total_bonded')"
                       >
                         {{ formatAmount(data.item.totalStake) }}
                       </span>
@@ -226,14 +226,14 @@
                     v-b-tooltip.hover
                     class="fas fa-star"
                     style="color: #f1bd23"
-                    :title="$t('pages.intention.remove_from_favorites')"
+                    :title="$t('pages.intentions.remove_from_favorites')"
                   />
                   <i
                     v-else
                     v-b-tooltip.hover
                     class="fas fa-star"
                     style="color: #e6dfdf;"
-                    :title="$t('pages.intention.add_to_favorites')"
+                    :title="$t('pages.intentions.add_to_favorites')"
                   />
                 </a>
               </p>

--- a/pages/intentions.vue
+++ b/pages/intentions.vue
@@ -280,7 +280,7 @@ export default {
     return {
       tableOptions: numItemsTableOptions,
       perPage: localStorage.numItemsTableSelected
-        ? localStorage.numItemsTableSelected
+        ? parseInt(localStorage.numItemsTableSelected)
         : 10,
       currentPage: 1,
       sortBy: `favorite`,
@@ -440,7 +440,7 @@ export default {
   },
   methods: {
     handleNumFields(num) {
-      this.perPage = num;
+      this.perPage = parseInt(num);
     },
     toggleFavorite(accountId) {
       if (this.favorites.indexOf(accountId) !== -1) {

--- a/pages/nominators.vue
+++ b/pages/nominators.vue
@@ -217,7 +217,7 @@ export default {
       polling: null,
       tableOptions: numItemsTableOptions,
       perPage: localStorage.numItemsTableSelected
-        ? localStorage.numItemsTableSelected
+        ? parseInt(localStorage.numItemsTableSelected)
         : 10,
       currentPage: 1,
       sortBy: `favorite`,
@@ -409,7 +409,7 @@ export default {
   },
   methods: {
     handleNumFields(num) {
-      this.perPage = num;
+      this.perPage = parseInt(num);
     },
     toggleFavorite(accountId) {
       if (this.favorites.indexOf(accountId) !== -1) {

--- a/pages/phragmen.vue
+++ b/pages/phragmen.vue
@@ -304,7 +304,7 @@ export default {
       enabled: false,
       tableOptions: numItemsTableOptions,
       perPage: localStorage.numItemsTableSelected
-        ? localStorage.numItemsTableSelected
+        ? parseInt(localStorage.numItemsTableSelected)
         : 10,
       currentPage: 1,
       sortBy: `rank`,
@@ -477,7 +477,7 @@ export default {
   },
   methods: {
     handleNumFields(num) {
-      this.perPage = num;
+      this.perPage = parseInt(num);
     },
     toggleFavorite(accountId) {
       if (this.favorites.indexOf(accountId) !== -1) {

--- a/pages/validators.vue
+++ b/pages/validators.vue
@@ -507,7 +507,7 @@ export default {
     return {
       tableOptions: numItemsTableValidatorOptions,
       perPage: localStorage.numItemsTableSelected
-        ? localStorage.numItemsTableSelected
+        ? parseInt(localStorage.numItemsTableSelected)
         : 10,
       currentPage: 1,
       sortBy: `favorite`,
@@ -846,7 +846,7 @@ export default {
     },
     handleNumFields(num) {
       localStorage.numItemsTableSelected = num;
-      this.perPage = num;
+      this.perPage = parseInt(num);
     },
     toggleFavorite(accountId) {
       if (this.favorites.indexOf(accountId) !== -1) {


### PR DESCRIPTION
Closes #10 

**Description:**

We was getting a lot of warning about an invalid value for pagination.
It was due to get the value from localstorage and pass directly to the table when it need a Number value.

This PR also fix another warning caused for a typo in translations strings.

Thank you! 🚀

---

For contributor:

- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI