### PR TITLE
Add information about load can take long time

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -82,7 +82,8 @@
       "add_to_favorites": "Add to Favorites",
       "identity": "Identity",
       "head_title": "PolkaStats - Polkadot Kusama active accounts",
-      "head_content": "Polkadot Kusama active accounts"
+      "head_content": "Polkadot Kusama active accounts",
+      "loading_data": "Loading data, it can tale a long time. Be patient, please"
     },
     "events": {
       "latest_5000_kusama_events": "Latest 5,000 Kusama events",

--- a/locales/es.json
+++ b/locales/es.json
@@ -68,7 +68,7 @@
       "show_last_block_and_sessionera_info": "Mostrar información del último bloque y sesión/era",
       "improved_navigation_speed": "Mejorada la velocidad de navegación",
       "head_title": "PolkaStats - Sobre PolkaStats",
-      "head_content": "Cuentas activas en Polkadot Kusama"
+      "head_content": "Sobre Polkadot"
     },
     "accounts": {
       "active_accounts": "Cuentas activas",
@@ -82,7 +82,9 @@
       "remove_from_favorites": "Eliminar de Favoritos",
       "add_to_favorites": "Añadir a Favoritos",
       "identity": "Identidad",
-      "head_title": "PolkaStats - Cuentas activas en Polkadot Kusama"
+      "head_title": "PolkaStats - Cuentas activas en Polkadot Kusama",
+      "head_content": "Cuentas activas en Polkadot Kusama",
+      "loading_data": "Cargando datos, puede tardar tiempo. Sea paciente, por favor"
     },
     "events": {
       "latest_5000_kusama_events": "ültimos 5,000 eventos en Kusama",

--- a/pages/accounts.vue
+++ b/pages/accounts.vue
@@ -58,6 +58,17 @@
           </b-col>
         </div>
         <!-- Table with sorting and pagination-->
+        <div v-if="!busy">
+          <b-alert
+            show
+            dismissible
+            variant="primary"
+            class="text-center"
+            data-testid="serverAlert"
+          >
+            <div>{{ $t("pages.accounts.loading_data") }}</div>
+          </b-alert>
+        </div>
         <div>
           <b-table
             id="accounts-table"
@@ -71,6 +82,7 @@
             :sort-desc.sync="sortDesc"
             :filter="filter"
             :filter-included-fields="filterOn"
+            :busy="busy"
             @filtered="onFiltered"
           >
             <template slot="rank" slot-scope="data">
@@ -230,6 +242,7 @@ export default {
   mixins: [commonMixin],
   data: function() {
     return {
+      busy: false,
       tableOptions: numItemsTableOptions,
       perPage: localStorage.numItemsTableSelected
         ? parseInt(localStorage.numItemsTableSelected)
@@ -286,15 +299,18 @@ export default {
   computed: {
     accounts() {
       let accounts = [];
-      for (let i = 0; i < this.$store.state.accounts.list.length; i++) {
-        let account = this.$store.state.accounts.list[i];
-        const accountIndex = account.accountIndex;
+      if (this.$store.state.accounts.dataLoaded) {
+        for (let i = 0; i < this.$store.state.accounts.list.length; i++) {
+          let account = this.$store.state.accounts.list[i];
+          const accountIndex = account.accountIndex;
 
-        accounts.push({
-          ...account,
-          accountIndex,
-          favorite: this.isFavorite(account.accountId)
-        });
+          accounts.push({
+            ...account,
+            accountIndex,
+            favorite: this.isFavorite(account.accountId)
+          });
+        }
+        this.setDataLoaded();
       }
       return accounts;
     },
@@ -357,6 +373,9 @@ export default {
       // Trigger pagination to update the number of buttons/pages due to filtering
       this.totalRows = filteredItems.length;
       this.currentPage = 1;
+    },
+    setDataLoaded() {
+      this.busy = true;
     }
   },
   head() {
@@ -390,5 +409,8 @@ export default {
 }
 .btn-secondary {
   font-size: 0.8rem;
+}
+table.b-table[aria-busy="true"] {
+  opacity: 1;
 }
 </style>

--- a/store/accounts.js
+++ b/store/accounts.js
@@ -3,7 +3,8 @@ import { isHex } from "@polkadot/util";
 import gql from "graphql-tag";
 
 export const state = () => ({
-  list: []
+  list: [],
+  dataLoaded: false
 });
 
 export const mutations = {
@@ -46,6 +47,7 @@ export const mutations = {
           rank: index + 1
         };
       });
+    state.dataLoaded = true;
   },
   getters: function() {
     state => state.list;


### PR DESCRIPTION
Closes #18 

**Description:**

Add an info alert in the accounts page to advise that load the table takes a long time.

Thank you! 🚀

---

For contributor:

- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI