### PR TITLE
Add top rich accounts to dashboard, fix incorrect order in accounts

### DIFF
--- a/components/Top10Rich.vue
+++ b/components/Top10Rich.vue
@@ -4,25 +4,23 @@
       <b-table striped hover :fields="fields" :items="richList">
         <template slot="account_id" slot-scope="data">
           <p class="mb-0 d-inline-block">
+            <Identicon
+              :key="data.item.account_id"
+              :value="data.item.account_id"
+              :size="20"
+              :theme="'polkadot'"
+            />
             <nuxt-link
               v-b-tooltip.hover
               :to="`/account?accountId=${data.item.account_id}`"
               title="Check account information"
             >
-              <Identicon
-                :key="data.item.account_id"
-                :value="data.item.account_id"
-                :size="20"
-                :theme="'polkadot'"
-              />
               {{ shortAddress(data.item.account_id) }}
             </nuxt-link>
           </p>
         </template>
-        <template slot="balances" slot-scope="data">
-          <p class="mb-0">
-            {{ formatAmount(JSON.parse(data.item.balances).freeBalance) }} KSM
-          </p>
+        <template slot="free_balance" slot-scope="data">
+          <p class="mb-0">{{ formatAmount(data.item.free_balance) }}</p>
         </template>
       </b-table>
     </div>
@@ -49,8 +47,8 @@ export default {
           sortable: true
         },
         {
-          key: "balances",
-          label: "Balances",
+          key: "free_balance",
+          label: "Balance",
           sortable: true
         }
       ]
@@ -61,10 +59,10 @@ export default {
       account: {
         query: gql`
           subscription accounts {
-            account(order_by: { account_id: desc }, where: {}, limit: 10) {
+            account(order_by: { free_balance: desc }, where: {}, limit: 10) {
               account_id
               identity
-              balances
+              free_balance
             }
           }
         `,

--- a/pages/accounts.vue
+++ b/pages/accounts.vue
@@ -298,21 +298,12 @@ export default {
   },
   computed: {
     accounts() {
-      let accounts = [];
-      if (this.$store.state.accounts.dataLoaded) {
-        for (let i = 0; i < this.$store.state.accounts.list.length; i++) {
-          let account = this.$store.state.accounts.list[i];
-          const accountIndex = account.accountIndex;
-
-          accounts.push({
-            ...account,
-            accountIndex,
-            favorite: this.isFavorite(account.accountId)
-          });
-        }
-        this.setDataLoaded();
-      }
-      return accounts;
+      return this.$store.state.accounts.list.map(account => {
+        return {
+          ...account,
+          favorite: this.isFavorite(account.accountId)
+        };
+      });
     },
     sortOptions() {
       // Create an options list from our fields

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -25,8 +25,8 @@
             <LastExtrinsics />
           </div>
           <div class="col-md-6 mb-4">
-            <!-- <h2>Top 10 rich accounts</h2>
-            <Top10Rich /> -->
+            <h2>Top 10 rich accounts</h2>
+            <Top10Rich />
           </div>
         </div>
       </b-container>
@@ -38,14 +38,14 @@ import Chain from "../components/Chain.vue";
 import LastBlocks from "../components/LastBlocks.vue";
 import LastEvents from "../components/LastEvents.vue";
 import LastExtrinsics from "../components/LastExtrinsics.vue";
-// import Top10Rich from "../components/Top10Rich.vue";
+import Top10Rich from "../components/Top10Rich.vue";
 export default {
   components: {
     Chain,
     LastBlocks,
     LastEvents,
-    LastExtrinsics
-    // Top10Rich
+    LastExtrinsics,
+    Top10Rich
   },
   head() {
     return {

--- a/store/accounts.js
+++ b/store/accounts.js
@@ -9,44 +9,16 @@ export const state = () => ({
 
 export const mutations = {
   update(state, accounts) {
-    state.list = accounts
-      .map(account => {
-        return {
-          accountId: account.account_id,
-          identity: account.identity !== "" ? JSON.parse(account.identity) : "",
-          availableBalance: JSON.parse(account.balances).availableBalance,
-          freeBalance: JSON.parse(account.balances).freeBalance,
-          lockedBalance: JSON.parse(account.balances).lockedBalance,
-          balances: JSON.parse(account.balances)
-        };
-      })
-      .sort(function compare(a, b) {
-        let BNA, BNB;
-        if (isHex(a.freeBalance)) {
-          BNA = new BN(a.freeBalance.substring(2, a.freeBalance.length), 16);
-        } else {
-          BNA = new BN(a.freeBalance, 10);
-        }
-        if (isHex(b.freeBalance)) {
-          BNB = new BN(b.freeBalance.substring(2, b.freeBalance.length), 16);
-        } else {
-          BNB = new BN(b.freeBalance, 10);
-        }
-
-        if (BNA.lt(BNB)) {
-          return 1;
-        }
-        if (BNA.gt(BNB)) {
-          return -1;
-        }
-        return 0;
-      })
-      .map((account, index) => {
-        return {
-          ...account,
-          rank: index + 1
-        };
-      });
+    state.list = accounts.map((account, index) => {
+      return {
+        rank: index + 1,
+        accountId: account.account_id,
+        identity: account.identity_display,
+        availableBalance: account.available_balance,
+        freeBalance: account.free_balance,
+        lockedBalance: account.locked_balance
+      };
+    });
     state.dataLoaded = true;
   },
   getters: function() {
@@ -59,11 +31,12 @@ export const actions = {
     const client = this.app.apolloProvider.defaultClient;
     const query = gql`
       query account {
-        account {
+        account(order_by: { free_balance: desc }, where: {}) {
           account_id
-          balances
-          block_height
-          identity
+          identity_display
+          available_balance
+          free_balance
+          locked_balance
         }
       }
     `;


### PR DESCRIPTION
Closes #47 
Closes #26 

**Description:**

- Add top rich accounts to dashboard.
- Fix incorrect order in accounts
- Simplify and optimize accounts page

Thank you! 🚀

---

For contributor:

- [x] Reviewed `Files changed` in the github PR explorer
- [x] Attach screenshots of the UI components on the PR description (if applicable)
- [x] Scope of work approved for big PRs

For reviewer:

- [x] Manually tested the changes on the UI