### PR TITLE
Fix BAT link text typo in Footer

### DIFF
--- a/cypress/integration/layout.spec.js
+++ b/cypress/integration/layout.spec.js
@@ -297,7 +297,7 @@ context("Footer", function() {
         .as("bat")
         .should("have.attr", "href", "https://basicattentiontoken.org/")
         .and("have.attr", "target", "_blank")
-        .contains("Basic Atttention Token");
+        .contains("Basic Attention Token");
 
       cy.get("@bat")
         .find("img")

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -234,7 +234,7 @@
             href="https://basicattentiontoken.org/"
             target="_blank"
             data-testid="bat"
-            >Basic Atttention Token
+            >Basic Attention Token
             <img src="/img/brave/logo-full-color.png" class="img-fluid bat"
           /></a>
           <span class="mx-2">|</span>


### PR DESCRIPTION
Closes #90

**Description:**

This is a typo fix for the "Built with Basic Attention Token" in the footer. 

---

For contributor:

- [ 
![BatTypoFixed](https://user-images.githubusercontent.com/1872389/110545180-574c6f00-80f2-11eb-8f24-472f07213862.png)
] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI